### PR TITLE
Cargo.toml: added release profile options optimizing for binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,5 +34,9 @@ mime_guess = "2.0"
 
 [profile.release]
 strip = "symbols"
-opt-level = "s"
 lto = true
+
+[profile.release-tiny]
+inherits = "release"
+opt-level = "s"
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,8 @@ atty = "0.2"
 matrix-sdk = { version = "0.4", default-features = false, features = ["rustls-tls", "markdown"] }
 mime = "0.3"
 mime_guess = "2.0"
+
+[profile.release]
+strip = "symbols"
+opt-level = "s"
+lto = true


### PR DESCRIPTION
I noticed that the release binary, when build with `cargo build --release`, isn't optimized for size. I made a few changes to `Cargo.toml` by introducing options to the release profile in favor of a smaller binary size reducing it from 19mb to 6,4mb.

```
-rwxr-xr-x 1 w w 6,4M  1. Apr 18:10 matrix-send-release-optimized
-rwxr-xr-x 1 w w  19M  1. Apr 17:56 matrix-send-release-orig
```

This comes at the cost of stripping symbols from the binary when using the release profile. I also enabled link-time optimization, which comes with the cost of a slightly increased compile time but generally should benefit performance, thus I'd consider it as a sane default (setting lto to true performs lto across all crates within the dependency graph).

If I'll manage to have some more time to spare, I'd be willing to put more thought into how to optimize the binary size further, however going down to a third of the original binary size seems like a good start.